### PR TITLE
fix: remove invalid Productivity category to fix release workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "vscode": "^1.74.0"
   },
   "categories": [
-    "Other",
-    "Productivity"
+    "Other"
   ],
   "keywords": [
     "path",


### PR DESCRIPTION
Fix release workflow error by removing invalid category.

## Problem
The release workflow was failing with:
```
The category 'Productivity' is not available in language 'en-us'.
```

## Solution
- Remove 'Productivity' from categories array
- Keep only 'Other' which is a valid VS Code category

## Impact
- Release workflow will succeed
- Extension remains discoverable through keywords
- No functional changes to the extension

After merging, we need to run the release workflow again.

🤖 Generated with [Claude Code](https://claude.ai/code)