### PR TITLE
fix: support path copying for non-text files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,13 +10,14 @@ export function activate(context: vscode.ExtensionContext) {
     const copyAbsolutePathCommand = vscode.commands.registerCommand(
         'editor-path-copier.copyAbsolutePath',
         (uri?: vscode.Uri) => {
-            const activeEditor = vscode.window.activeTextEditor
-            if (!activeEditor) {
+            const filePath =
+                uri?.fsPath ??
+                vscode.window.activeTextEditor?.document.uri.fsPath
+            if (!filePath) {
                 vscode.window.showWarningMessage('No active editor found')
                 return
             }
 
-            const filePath = uri ? uri.fsPath : activeEditor.document.uri.fsPath
             vscode.env.clipboard.writeText(filePath)
             vscode.window.showInformationMessage(
                 `Copied absolute path: ${filePath}`,
@@ -28,13 +29,13 @@ export function activate(context: vscode.ExtensionContext) {
     const copyRelativePathCommand = vscode.commands.registerCommand(
         'editor-path-copier.copyRelativePath',
         (uri?: vscode.Uri) => {
-            const activeEditor = vscode.window.activeTextEditor
-            if (!activeEditor) {
+            const filePath =
+                uri?.fsPath ??
+                vscode.window.activeTextEditor?.document.uri.fsPath
+            if (!filePath) {
                 vscode.window.showWarningMessage('No active editor found')
                 return
             }
-
-            const filePath = uri ? uri.fsPath : activeEditor.document.uri.fsPath
             const workspaceFolder = vscode.workspace.getWorkspaceFolder(
                 vscode.Uri.file(filePath),
             )


### PR DESCRIPTION
## Summary

- Fix path copying failure for non-text files such as images and PDFs
- Prioritize `uri` parameter and use `activeTextEditor` as a fallback

## Background

When invoked from the editor toolbar button, the `uri` parameter is passed. However, the code checked `vscode.window.activeTextEditor` first and returned early if it was `undefined`. Since images and PDFs are opened in custom editors (not text editors), `activeTextEditor` is `undefined`, causing the "No active editor found" error.

## Test plan

- [ ] Verify absolute/relative path copy works for text files
- [ ] Verify absolute/relative path copy works for image files (PNG, JPG, etc.)
- [ ] Verify absolute/relative path copy works for PDF files