### PR TITLE
chore: add .vscodeignore to reduce VSIX package size

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,12 @@
+.github/**
+.vscode-test/**
+scripts/**
+src/**
+node_modules/**
+coverage/**
+*.vsix
+.DS_Store
+.gitignore
+biome.json
+tsconfig.json
+CONTRIBUTING.md


### PR DESCRIPTION
## Summary

- Add `.vscodeignore` to exclude unnecessary files from the VSIX package
- Reduces package size from 12KB to 7.7KB (10 files included)

## Excluded files

- `src/`, `node_modules/`, `coverage/`, `.github/`, `scripts/`
- Config files: `biome.json`, `tsconfig.json`, `.gitignore`
- `CONTRIBUTING.md`, `*.vsix`, `.DS_Store`

## Test plan

- [ ] `npm run package` succeeds and only includes necessary files
- [ ] Extension works correctly after installing the packaged VSIX